### PR TITLE
color-it 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,23 @@ $ npm i --save color-it
 
 
 ```js
-// Dependencies
-var ColorIt = require("color-it")
-  , IterateObject = require("iterate-object")
-  ;
+const colorIt = require("color-it")
+    , iterateObj = require("iterate-object")
+    ;
 
 // Red on dark blue
-console.log("Hello " + ColorIt("World").orange().wetAsphaltBg() + "!");
+console.log("Hello " + colorIt("World").orange().wetAsphaltBg() + "!");
 
 // Rainbow!
 console.log(
-    ColorIt("Flat Colors Rainbow: ").gray()
-  + "\n" + ColorIt(" ".repeat(7)).red().redBg() + " " + ColorIt("Red").red()
-  + "\n" + ColorIt(" ".repeat(7)).orange().orangeBg() + " " + ColorIt("Orange").orange()
-  + "\n" + ColorIt(" ".repeat(7)).yellow().yellowBg() + " " + ColorIt("Yellow").yellow()
-  + "\n" + ColorIt(" ".repeat(7)).green().greenBg() + " " + ColorIt("Green").green()
-  + "\n" + ColorIt(" ".repeat(7)).blue().blueBg() + " " + ColorIt("Blue").blue()
-  + "\n" + ColorIt(" ".repeat(7)).purple().purpleBg() + " " + ColorIt("Purple").purple()
-  + "\n" + ColorIt(" ".repeat(7)).indigo().indigoBg() + " " + ColorIt("Indigo").indigo()
+    colorIt("Flat Colors Rainbow: ").gray()
+  + "\n" + colorIt(" ".repeat(7)).red().redBg() + " " + colorIt("Red").red()
+  + "\n" + colorIt(" ".repeat(7)).orange().orangeBg() + " " + colorIt("Orange").orange()
+  + "\n" + colorIt(" ".repeat(7)).yellow().yellowBg() + " " + colorIt("Yellow").yellow()
+  + "\n" + colorIt(" ".repeat(7)).green().greenBg() + " " + colorIt("Green").green()
+  + "\n" + colorIt(" ".repeat(7)).blue().blueBg() + " " + colorIt("Blue").blue()
+  + "\n" + colorIt(" ".repeat(7)).purple().purpleBg() + " " + colorIt("Purple").purple()
+  + "\n" + colorIt(" ".repeat(7)).indigo().indigoBg() + " " + colorIt("Indigo").indigo()
 );
 
 // All the available colors
@@ -48,8 +47,8 @@ var allColors = ""
   , newLine = false
   ;
 
-IterateObject(ColorIt.prototype, function (_, c) {
-    allColors += ColorIt("ColorIt." + c + "()")[c]() + " ";
+iterateObj(colorIt.prototype, function (_, c) {
+    allColors += colorIt("colorIt." + c + "()")[c]() + " ";
     if (!!(newLine = !newLine)) {
         allColors += "\n";
     }

--- a/example/index.js
+++ b/example/index.js
@@ -1,21 +1,22 @@
-// Dependencies
-var ColorIt = require("../lib")
-  , IterateObject = require("iterate-object")
-  ;
+"use strict";
+
+const colorIt = require("../lib")
+    , iterateObj = require("iterate-object")
+    ;
 
 // Red on dark blue
-console.log("Hello " + ColorIt("World").orange().wetAsphaltBg() + "!");
+console.log("Hello " + colorIt("World").orange().wetAsphaltBg() + "!");
 
 // Rainbow!
 console.log(
-    ColorIt("Flat Colors Rainbow: ").gray()
-  + "\n" + ColorIt(" ".repeat(7)).red().redBg() + " " + ColorIt("Red").red()
-  + "\n" + ColorIt(" ".repeat(7)).orange().orangeBg() + " " + ColorIt("Orange").orange()
-  + "\n" + ColorIt(" ".repeat(7)).yellow().yellowBg() + " " + ColorIt("Yellow").yellow()
-  + "\n" + ColorIt(" ".repeat(7)).green().greenBg() + " " + ColorIt("Green").green()
-  + "\n" + ColorIt(" ".repeat(7)).blue().blueBg() + " " + ColorIt("Blue").blue()
-  + "\n" + ColorIt(" ".repeat(7)).purple().purpleBg() + " " + ColorIt("Purple").purple()
-  + "\n" + ColorIt(" ".repeat(7)).indigo().indigoBg() + " " + ColorIt("Indigo").indigo()
+    colorIt("Flat Colors Rainbow: ").gray()
+  + "\n" + colorIt(" ".repeat(7)).red().redBg() + " " + colorIt("Red").red()
+  + "\n" + colorIt(" ".repeat(7)).orange().orangeBg() + " " + colorIt("Orange").orange()
+  + "\n" + colorIt(" ".repeat(7)).yellow().yellowBg() + " " + colorIt("Yellow").yellow()
+  + "\n" + colorIt(" ".repeat(7)).green().greenBg() + " " + colorIt("Green").green()
+  + "\n" + colorIt(" ".repeat(7)).blue().blueBg() + " " + colorIt("Blue").blue()
+  + "\n" + colorIt(" ".repeat(7)).purple().purpleBg() + " " + colorIt("Purple").purple()
+  + "\n" + colorIt(" ".repeat(7)).indigo().indigoBg() + " " + colorIt("Indigo").indigo()
 );
 
 // All the available colors
@@ -23,8 +24,8 @@ var allColors = ""
   , newLine = false
   ;
 
-IterateObject(ColorIt.prototype, function (_, c) {
-    allColors += ColorIt("ColorIt." + c + "()")[c]() + " ";
+iterateObj(colorIt.prototype, function (_, c) {
+    allColors += colorIt("colorIt." + c + "()")[c]() + " ";
     if (!!(newLine = !newLine)) {
         allColors += "\n";
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,9 @@
 // Dependencies
-var Couleurs = require("couleurs")
-  , FlatColors = require("flat-colors")
-  , IterateObject = require("iterate-object")
-  ;
+const couleurs = require("couleurs")
+    , flatColors = require("flat-colors")
+    , iterateObject = require("iterate-object")
+    , typpy = require("typpy")
+    ;
 
 /**
  * ColorIt
@@ -51,7 +52,7 @@ var Couleurs = require("couleurs")
  * @return {ColorIt} The `ColorIt` instance.
  */
 function ColorIt(text) {
-    if (this.constructor !== ColorIt) {
+    if (!typpy(this, ColorIt)) {
         return new ColorIt(text);
     }
     this.styles = {};
@@ -69,14 +70,14 @@ function ColorIt(text) {
  */
 ColorIt.prototype.toString = function () {
     var output = this.text;
-    IterateObject(this.styles, function (color, type) {
-        output = Couleurs[type](output, color);
+    iterateObject(this.styles, function (color, type) {
+        output = couleurs[type](output, color);
     });
     return output;
 };
 
 // Red, Orange, Yellow, Green, Blue, Indigo, Purple
-IterateObject(FlatColors._, function (color, name) {
+iterateObject(flatColors._, function (color, name) {
 
     ColorIt.prototype[name] = function () {
         this.styles.fg = color;
@@ -100,7 +101,7 @@ ColorIt.aliases = {
   , gray: "concrete"
 };
 
-IterateObject(ColorIt.aliases, function (c, n) {
+iterateObject(ColorIt.aliases, function (c, n) {
     ColorIt.prototype[n] = ColorIt.prototype[c];
     ColorIt.prototype[n + "Bg"] = ColorIt.prototype[c + "Bg"];
 });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "couleurs": "^5.0.0",
     "flat-colors": "^3.1.0",
-    "iterate-object": "^1.1.0"
+    "iterate-object": "^1.1.0",
+    "typpy": "^2.3.3"
   },
   "files": [
     "bin/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color-it",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Flat colors for your Node.js strings.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Fix a bug that appears in strict mode.

`this` is undefined when not calling the function using `new`, so use `typpy` to check if the context is a current instance, otherwise, create one. :boom:
